### PR TITLE
Allow multiline chat input and UI customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,18 @@
                     <label for="model-input">Model Name:</label>
                     <input type="text" id="model-input" name="model-input" placeholder="e.g., gpt-4" required aria-required="true">
                 </div>
+                <div class="form-group">
+                    <label for="chat-width">Chat Width (px):</label>
+                    <input type="number" id="chat-width" name="chat-width" min="400" max="1200" placeholder="800">
+                </div>
+                <div class="form-group">
+                    <label for="chat-height">Chat Height (vh):</label>
+                    <input type="number" id="chat-height" name="chat-height" min="40" max="100" placeholder="80">
+                </div>
+                <div class="form-group">
+                    <label for="chat-font-size">Chat Font Size (px):</label>
+                    <input type="number" id="chat-font-size" name="chat-font-size" min="12" max="24" placeholder="16">
+                </div>
                 <button type="submit" class="save-btn">Save Settings</button>
             </form>
         </div>

--- a/script.js
+++ b/script.js
@@ -16,9 +16,9 @@ document.addEventListener("DOMContentLoaded", () => {
     const conversationList = document.getElementById("conversation-list");
     const exportChatBtn = document.getElementById("export-chat-btn");
     const regenerateTitleBtn = document.getElementById("regenerate-title-btn"); // New Button
-        // Add Dark Mode Toggle Button Listener
     const darkModeToggle = document.getElementById("dark-mode-toggle");
     const body = document.body;
+    const searchInput = document.getElementById("search");
     // Chat State
     let conversations = {}; // Object to hold multiple conversations
     let currentConversationId = null;
@@ -28,6 +28,9 @@ document.addEventListener("DOMContentLoaded", () => {
     let apiUrl = "";
     let apiKey = "";
     let selectedModel = "";
+    let chatWidth = "800"; // px
+    let chatHeight = "80"; // vh
+    let chatFontSize = "16"; // px
 
     // Prevent multiple event listener attachments
     let isEventListenerAttached = false;
@@ -48,7 +51,7 @@ document.addEventListener("DOMContentLoaded", () => {
         form.addEventListener("submit", async (event) => {
             event.preventDefault();
 
-            const searchContent = document.getElementById("search").value.trim();
+            const searchContent = searchInput.value.trim();
 
             if (!searchContent) {
                 alert("Please enter your query.");
@@ -89,7 +92,8 @@ document.addEventListener("DOMContentLoaded", () => {
             hideLoading();
 
             // Clear the input field after submission
-            document.getElementById("search").value = "";
+            searchInput.value = "";
+            searchInput.style.height = "auto";
         });
 
         closeSidebarBtn.addEventListener("click", () => {
@@ -144,12 +148,18 @@ document.addEventListener("DOMContentLoaded", () => {
             regenerateChatTitle();
         });
 
-        // Keyboard Shortcuts (e.g., Enter to send, Shift+Enter for newline)
-        document.getElementById("search").addEventListener("keydown", function(event) {
-            if (event.key === "Enter" && !event.shiftKey) {
+        // Keyboard Shortcuts: Ctrl+Enter to send
+        searchInput.addEventListener("keydown", function(event) {
+            if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
                 event.preventDefault();
                 form.dispatchEvent(new Event('submit'));
             }
+        });
+
+        // Auto-resize textarea to fit content
+        searchInput.addEventListener("input", () => {
+            searchInput.style.height = "auto";
+            searchInput.style.height = searchInput.scrollHeight + "px";
         });
 
         // Save edited chat title on blur
@@ -412,6 +422,12 @@ document.addEventListener("DOMContentLoaded", () => {
     function openSettingsModal() {
         settingsModal.classList.remove("hidden");
         // Focus on the first input for accessibility
+        document.getElementById("api-url").value = apiUrl;
+        document.getElementById("api-key").value = apiKey;
+        document.getElementById("model-input").value = selectedModel;
+        document.getElementById("chat-width").value = chatWidth;
+        document.getElementById("chat-height").value = chatHeight;
+        document.getElementById("chat-font-size").value = chatFontSize;
         document.getElementById("api-url").focus();
     }
 
@@ -429,6 +445,9 @@ document.addEventListener("DOMContentLoaded", () => {
         const apiUrlInput = document.getElementById("api-url").value.trim();
         const apiKeyInput = document.getElementById("api-key").value.trim();
         const modelInput = document.getElementById("model-input").value.trim();
+        const chatWidthInput = document.getElementById("chat-width").value.trim();
+        const chatHeightInput = document.getElementById("chat-height").value.trim();
+        const chatFontSizeInput = document.getElementById("chat-font-size").value.trim();
 
         if (!apiUrlInput) {
             alert("API URL is required.");
@@ -443,11 +462,19 @@ document.addEventListener("DOMContentLoaded", () => {
         apiUrl = apiUrlInput;
         apiKey = apiKeyInput;
         selectedModel = modelInput;
+        chatWidth = chatWidthInput || chatWidth;
+        chatHeight = chatHeightInput || chatHeight;
+        chatFontSize = chatFontSizeInput || chatFontSize;
 
         // Save settings to localStorage
         localStorage.setItem("apiUrl", apiUrl);
         localStorage.setItem("apiKey", apiKey);
         localStorage.setItem("selectedModel", selectedModel);
+        localStorage.setItem("chatWidth", chatWidth);
+        localStorage.setItem("chatHeight", chatHeight);
+        localStorage.setItem("chatFontSize", chatFontSize);
+
+        applyChatSettings();
 
         // Save chat title if edited
         const editedTitle = chatTitleElement.textContent.trim();
@@ -462,12 +489,25 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     /**
+     * Applies chat appearance settings to the document.
+     */
+    function applyChatSettings() {
+        document.documentElement.style.setProperty('--chat-max-width', `${chatWidth}px`);
+        document.documentElement.style.setProperty('--chat-height', `${chatHeight}vh`);
+        document.documentElement.style.setProperty('--chat-font-size', `${chatFontSize}px`);
+    }
+
+    /**
      * Loads settings from localStorage.
      */
     function loadSettings() {
         apiUrl = localStorage.getItem("apiUrl") || "";
         apiKey = localStorage.getItem("apiKey") || "";
         selectedModel = localStorage.getItem("selectedModel") || "";
+        chatWidth = localStorage.getItem("chatWidth") || chatWidth;
+        chatHeight = localStorage.getItem("chatHeight") || chatHeight;
+        chatFontSize = localStorage.getItem("chatFontSize") || chatFontSize;
+        applyChatSettings();
         const savedTitle = localStorage.getItem("chatTitle") || "";
 
         if (savedTitle && savedTitle !== "ChatGPT Assistant") {

--- a/style.css
+++ b/style.css
@@ -13,6 +13,12 @@ body {
     min-height: 100vh;
 }
 
+:root {
+    --chat-max-width: 800px;
+    --chat-height: 80vh;
+    --chat-font-size: 16px;
+}
+
 /* Add font-face rule for local fonts */
 @font-face {
     font-family: 'ComicMono';
@@ -210,13 +216,14 @@ main {
 
 .chat-section {
     width: 100%;
-    max-width: 800px;
+    max-width: var(--chat-max-width);
     background-color: #fff;
     border-radius: 8px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     display: flex;
     flex-direction: column;
-    height: 80vh;
+    height: var(--chat-height);
+    font-size: var(--chat-font-size);
 }
 
 .chat-history {
@@ -249,9 +256,9 @@ main {
     padding: 0.75rem;
     border: 1px solid #ccc;
     border-radius: 4px;
-    resize: none;
-    font-size: 1rem;
-    height: 60px;
+    resize: vertical;
+    font-size: inherit;
+    min-height: 60px;
 }
 
 .chat-input button {
@@ -288,7 +295,7 @@ main {
 .message-content {
     max-width: 70%;
     padding: 0.75rem 1rem;
-    font-size: 1rem;
+    font-size: inherit;
     line-height: 1.4;
     position: relative;
     border-radius: 12px;


### PR DESCRIPTION
## Summary
- Enable multiline chat input with Enter and submission via Ctrl+Enter
- Add settings to control chat width, height, and font size
- Introduce CSS variables and auto-resizing textarea for flexible UI

## Testing
- `node --check script.js`
- `npx -y prettier --check index.html script.js style.css`

------
https://chatgpt.com/codex/tasks/task_e_68bbe837212083289e3a1c9b75bd7196