### PR TITLE
Handle multi-line chat messages

### DIFF
--- a/script.js
+++ b/script.js
@@ -217,8 +217,9 @@ document.addEventListener("DOMContentLoaded", () => {
             // Message content
             const messageContent = document.createElement("div");
             messageContent.classList.add("message-content");
+            const formattedContent = sanitizeHTML(msg.content).replace(/\n/g, "<br>");
             messageContent.innerHTML = `
-                <strong>${capitalizeFirstLetter(msg.role)}:</strong> ${sanitizeHTML(msg.content)}
+                <strong>${capitalizeFirstLetter(msg.role)}:</strong> ${formattedContent}
                 <span class="timestamp">${new Date().toLocaleTimeString()}</span>
             `;
             messageElement.appendChild(messageContent);

--- a/style.css
+++ b/style.css
@@ -297,6 +297,7 @@ main {
     padding: 0.75rem 1rem;
     font-size: inherit;
     line-height: 1.4;
+    white-space: pre-line;
     position: relative;
     border-radius: 12px;
     display: flex;


### PR DESCRIPTION
## Summary
- ensure multiline messages display correctly by adding `white-space: pre-line` to message content styling
- convert newline characters to `<br>` in `updateChatHistory` for proper rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbeb6c5ff0832889061bb6875815c8