### PR TITLE
Clear input while awaiting assistant reply

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,6 +19,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const darkModeToggle = document.getElementById("dark-mode-toggle");
     const body = document.body;
     const searchInput = document.getElementById("search");
+    const submitBtn = document.getElementById("submit-btn");
     const modelSelect = document.getElementById("model-select");
     const newModelNameInput = document.getElementById("new-model-name");
     const newModelUrlInput = document.getElementById("new-model-url");
@@ -66,6 +67,12 @@ document.addEventListener("DOMContentLoaded", () => {
             updateChatHistory();
             scrollToBottom();
 
+            // Clear the input and disable input while waiting for reply
+            searchInput.value = "";
+            searchInput.style.height = "auto";
+            searchInput.disabled = true;
+            submitBtn.disabled = true;
+
             // Show loading indicator
             showLoading();
 
@@ -78,7 +85,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 // After the first user message and assistant response, prompt for chat title
                 // Ensure this only happens once
                 if (!chatTitleSet && getCurrentConversationMessages().length === 2) { // Only first interaction
-                    await promptForChatTitle();
+                    // Queue title generation without blocking user input
+                    promptForChatTitle();
                 }
             } catch (error) {
                 console.error("Fetch Error:", error);
@@ -90,14 +98,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
                 updateChatHistory();
                 scrollToBottom();
+            } finally {
+                // Hide loading indicator and re-enable input
+                hideLoading();
+                searchInput.disabled = false;
+                submitBtn.disabled = false;
+                searchInput.focus();
             }
-
-            // Hide loading indicator
-            hideLoading();
-
-            // Clear the input field after submission
-            searchInput.value = "";
-            searchInput.style.height = "auto";
         });
 
         closeSidebarBtn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- Clear user input immediately after sending
- Disable chat input and submit button while waiting for assistant reply
- Re-enable input once the assistant responds
- Queue chat title generation asynchronously after the initial reply

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3fa686cc83288e7e618675652f5e