### PR TITLE
Improve sidebar layout for chat interface

### DIFF
--- a/script.js
+++ b/script.js
@@ -44,6 +44,9 @@ document.addEventListener("DOMContentLoaded", () => {
     // Prevent multiple event listener attachments
     let isEventListenerAttached = false;
 
+    // Sidebar is visible by default
+    body.classList.add("sidebar-open");
+
     // Initialize Conversations
     loadConversations();
     loadSettings();
@@ -686,6 +689,7 @@ Return ONLY the title text with nothing else.`;
     function toggleSidebarVisibility() {
         sidebar.classList.toggle("hidden");
         sidebarclosed.classList.toggle("hidden");
+        body.classList.toggle("sidebar-open");
     }
 
     /**

--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@
     --chat-max-width: 800px;
     --chat-height: 80vh;
     --chat-font-size: 16px;
+    --sidebar-width: 250px;
     --color-primary: #4a90e2;
     --color-primary-hover: #357ab7;
     --color-background: #f5f7fa;
@@ -93,7 +94,7 @@ header .header-right button i {
 
 /* Sidebar Styles */
 .sidebar {
-    width: 300px;
+    width: var(--sidebar-width);
     background-color: #ffffff;
     border-right: 1px solid #ddd;
     padding: 1rem;
@@ -214,12 +215,12 @@ main {
     justify-content: center;
     align-items: center;
     padding: 2rem;
-    margin-left: 0; /* Adjusted for fixed sidebar */
+    margin-left: 0;
     transition: margin-left 0.3s ease-in-out;
 }
 
-.sidebar:not(.hidden) + main {
-    margin-left: 300px; /* Width of sidebar */
+body.sidebar-open main {
+    margin-left: var(--sidebar-width);
 }
 
 .chat-section {
@@ -626,7 +627,7 @@ footer {
         transform: translateX(-100%);
     }
 
-    .sidebar + main {
+    body.sidebar-open main {
         margin-left: 0;
     }
 }


### PR DESCRIPTION
## Summary
- Reduce sidebar footprint and introduce `--sidebar-width` variable
- Shift chat area when sidebar is visible via `sidebar-open` body class
- Ensure sidebar toggle updates layout consistently

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e0317ce48328923bedb321c7efd8