### PR TITLE
fix: clean copied code blocks

### DIFF
--- a/script.js
+++ b/script.js
@@ -452,7 +452,11 @@ document.addEventListener("DOMContentLoaded", () => {
             const messageContent = document.createElement("div");
             messageContent.classList.add("message-content");
             const formattedContent = sanitizeHTML(msg.content)
-                .replace(/```([\s\S]*?)```/g, (match, code) => `<pre><code>${code.replace(/\n/g, '\u0000')}</code></pre>`) 
+                .replace(/```(\w+)?\n?([\s\S]*?)```/g, (match, lang, code) => {
+                    const dataLang = lang ? ` data-lang="${lang}"` : "";
+                    const langClass = lang ? ` class="language-${lang}"` : "";
+                    return `<pre${dataLang}><code${langClass}>${code.replace(/\n/g, '\u0000')}</code></pre>`;
+                })
                 .replace(/\n/g, "<br>")
                 .replace(/\u0000/g, '\n');
             messageContent.innerHTML = `
@@ -502,7 +506,9 @@ document.addEventListener("DOMContentLoaded", () => {
             button.classList.add('copy-code-btn');
             button.textContent = 'Copy';
             button.addEventListener('click', () => {
-                navigator.clipboard.writeText(block.innerText);
+                const codeElement = block.querySelector('code');
+                const codeText = codeElement ? codeElement.innerText : block.innerText;
+                navigator.clipboard.writeText(codeText);
                 button.textContent = 'Copied!';
                 setTimeout(() => (button.textContent = 'Copy'), 2000);
             });

--- a/style.css
+++ b/style.css
@@ -309,18 +309,29 @@ main {
     border-radius: 16px 16px 16px 0;
 }
 
+
 .message-content pre {
     background-color: #f6f8fa;
     border-radius: 8px;
-    padding: 0.75rem;
+    padding: 1.5rem 0.75rem 0.75rem;
     margin-top: 0.5rem;
     overflow-x: auto;
     font-family: 'Fira Code', monospace;
     position: relative;
 }
 
+.message-content pre::before {
+    content: attr(data-lang);
+    position: absolute;
+    top: 0.25rem;
+    left: 0.5rem;
+    font-size: 0.75rem;
+    color: #555;
+}
+
 .message-content pre code {
     display: block;
+    color: #1e1e1e;
 }
 
 .copy-code-btn {
@@ -546,6 +557,14 @@ body.dark-mode .message.assistant .message-content {
 
 body.dark-mode .message-content pre {
     background-color: #2d2d2d;
+}
+
+body.dark-mode .message-content pre::before {
+    color: #ccc;
+}
+
+body.dark-mode .message-content pre code {
+    color: #e6e6e6;
 }
 
 body.dark-mode .copy-code-btn {


### PR DESCRIPTION
## Summary
- parse fenced code blocks for language and display as header
- copy button now copies only actual code content
- add styling for language labels in code blocks
- set explicit code colors for light and dark themes to improve readability

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfa430f5308328bc4fbf72f85a3d0a