### PR TITLE
Folders as projects: default prompts and models, message search, undo deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ChatSpark was built with the belief that talking to AI should be simple and plea
 - **Image support**: Attach, paste, or drag & drop images into the chat (sent using the OpenAI vision format; large images are downscaled automatically)
 - **System prompts**: Set a global default, give a folder its own default (folders act like projects), and override either per conversation
 - **Edit & regenerate**: Edit any of your messages and resend, or regenerate any assistant response in place — with a different model if you like
-- **Conversation management**: Auto-generated titles, folders, search, and per-chat export to Markdown or JSON
+- **Conversation management**: Auto-generated titles, folders, full-text search across titles and message content, undo for deleted messages and conversations, and per-chat export to Markdown or JSON
 - **Backup & restore**: Export all data to a single JSON file and import it on another machine
 - **Roomy storage**: Conversations (including images) live in IndexedDB, not the cramped 5 MB localStorage — existing chats are migrated automatically
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ChatSpark was built with the belief that talking to AI should be simple and plea
 - **Switch models mid-conversation**: A model picker lives right in the header; every response is tagged with the model that wrote it
 - **Streaming responses**: Replies render token-by-token with proper Markdown — headings, lists, tables, and syntax-highlighted code blocks with copy buttons
 - **Image support**: Attach, paste, or drag & drop images into the chat (sent using the OpenAI vision format; large images are downscaled automatically)
-- **System prompts**: Set a global default and override it per conversation
+- **System prompts**: Set a global default, give a folder its own default (folders act like projects), and override either per conversation
 - **Edit & regenerate**: Edit any of your messages and resend, or regenerate any assistant response in place — with a different model if you like
 - **Conversation management**: Auto-generated titles, folders, search, and per-chat export to Markdown or JSON
 - **Backup & restore**: Export all data to a single JSON file and import it on another machine

--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
                 <div class="form-group">
                     <label for="default-system-prompt">Default system prompt (new chats)</label>
                     <textarea id="default-system-prompt" rows="4" placeholder="e.g. You are a helpful assistant."></textarea>
-                    <small>Each chat can override this via the 📝 button in the header.</small>
+                    <small>Folders can set their own default (📝 on the folder), and each chat can override both via the 📝 button in the header.</small>
                 </div>
                 <div class="form-group form-row">
                     <div>

--- a/script.js
+++ b/script.js
@@ -54,14 +54,25 @@ function messageImages(content) {
  * Toasts, dialogs and popup menus (replacements for alert/prompt/confirm)
  * ========================================================================== */
 
-function toast(message, type = "info", duration = 3500) {
+function toast(message, type = "info", duration = 3500, action = null) {
     const container = $("#toast-container");
     const el = document.createElement("div");
     el.className = "toast" + (type !== "info" ? " " + type : "");
     el.textContent = message;
     container.appendChild(el);
     if (type === "error") duration = Math.max(duration, 5000);
-    setTimeout(() => el.remove(), duration);
+    let timer = setTimeout(() => el.remove(), duration);
+    if (action) {
+        const btn = document.createElement("button");
+        btn.className = "toast-action";
+        btn.textContent = action.label;
+        btn.addEventListener("click", () => {
+            clearTimeout(timer);
+            el.remove();
+            action.onClick();
+        });
+        el.appendChild(btn);
+    }
 }
 
 function baseDialog(innerHTML) {
@@ -386,6 +397,7 @@ let streamState = null;        // {controller} while a response is streaming
 let searchQuery = "";
 let editingDraft = null;       // connection being edited in settings
 let streamRenderTimer = null;
+let searchDebounceTimer = null;
 
 /* DOM references */
 let chatHistoryEl, chatForm, inputEl, submitBtn, stopBtn, attachBtn, imageInput,
@@ -514,6 +526,31 @@ function getActive() {
     const conn = connections.find(c => c.id === settings.activeConnectionId) || null;
     const model = conn && conn.models.includes(settings.activeModel) ? settings.activeModel : null;
     return { conn, model };
+}
+
+/* Returns pref if it points at a connection/model that still exist, else null. */
+function validModelPref(pref) {
+    if (!pref) return null;
+    const conn = connections.find(c => c.id === pref.connectionId);
+    if (!conn || !conn.models.includes(pref.model)) return null;
+    return pref;
+}
+
+/* Resolves the model preference for a conversation: its own pref, else the
+ * containing folder's default, else null. */
+function modelPrefFor(conv) {
+    return validModelPref(conv.modelPref) || validModelPref(folderOf(conv.id) && folderOf(conv.id).modelPref) || null;
+}
+
+/* Applies a conversation's (or its folder's) remembered model, if any. */
+function applyModelPref(conv) {
+    if (!conv) return;
+    const pref = modelPrefFor(conv);
+    if (!pref) return;
+    settings.activeConnectionId = pref.connectionId;
+    settings.activeModel = pref.model;
+    saveSettings();
+    renderModelPicker();
 }
 
 /* ==========================================================================
@@ -1001,10 +1038,27 @@ function deleteMessage(index) {
     if (streamState) return;
     const conv = currentConv();
     if (!conv || !conv.messages[index]) return;
+    const removedMessage = conv.messages[index];
+    const removedIndex = index;
+    const convId = conv.id;
     conv.messages.splice(index, 1);
     conv.updatedAt = Date.now();
     renderChatHistory();
     Store.put(conv).catch(e => console.error("Save failed:", e));
+    toast("Message deleted.", "info", 6000, {
+        label: "Undo",
+        onClick: () => {
+            const target = conversations[convId];
+            if (!target) return;
+            target.messages.splice(Math.min(removedIndex, target.messages.length), 0, removedMessage);
+            target.updatedAt = Date.now();
+            Store.put(target).catch(e => console.error("Save failed:", e));
+            if (currentConversationId === convId) {
+                renderChatHistory();
+                updateTokenEstimate();
+            }
+        },
+    });
 }
 
 function startEditMessage(index) {
@@ -1118,6 +1172,7 @@ function createNewConversation() {
     updateChatTitle();
     renderChatHistory();
     renderConversationList();
+    applyModelPref(conversations[id]);
     inputEl.focus();
 }
 
@@ -1128,6 +1183,7 @@ function switchConversation(id) {
     updateChatTitle();
     renderChatHistory();
     renderConversationList();
+    applyModelPref(conversations[id]);
     scrollToBottom(true);
 }
 
@@ -1140,9 +1196,8 @@ async function deleteConversation(id) {
     const conv = conversations[id];
     if (!conv) return;
     if (id === currentConversationId) stopStreaming();
-    const ok = await confirmDialog(`Delete "${conv.title}"? This cannot be undone.`,
-        { title: "Delete Conversation", confirmLabel: "Delete", danger: true });
-    if (!ok) return;
+    const snapshotConv = conv;
+    const snapshotFolderId = folderOf(id)?.id;
     Object.values(folders).forEach(folder => {
         const i = folder.conversations.indexOf(id);
         if (i !== -1) folder.conversations.splice(i, 1);
@@ -1162,6 +1217,19 @@ async function deleteConversation(id) {
     }
     renderConversationList();
     renderFolderList();
+    toast(`Deleted "${snapshotConv.title}".`, "info", 6000, {
+        label: "Undo",
+        onClick: () => {
+            conversations[id] = snapshotConv;
+            Store.put(snapshotConv).catch(e => console.error("Save failed:", e));
+            if (snapshotFolderId && folders[snapshotFolderId]) {
+                folders[snapshotFolderId].conversations.push(id);
+            }
+            saveFolders();
+            renderConversationList();
+            renderFolderList();
+        },
+    });
 }
 
 function convSortKey(conv) {
@@ -1171,15 +1239,41 @@ function convSortKey(conv) {
     return m ? parseInt(m[1], 10) : 0;
 }
 
+/* Builds a safe ~60-char snippet around the first match of `query` inside
+ * `text`, with the matched substring wrapped in <mark>. All pieces are
+ * escaped individually before assembly so the <mark> tags survive intact. */
+function buildSnippet(text, query, radius = 30) {
+    const lower = text.toLowerCase();
+    const q = query.toLowerCase();
+    const idx = lower.indexOf(q);
+    if (idx === -1) return "";
+    const start = Math.max(0, idx - radius);
+    const end = Math.min(text.length, idx + q.length + radius);
+    const prefix = (start > 0 ? "…" : "") + escapeHTML(text.slice(start, idx));
+    const match = escapeHTML(text.slice(idx, idx + q.length));
+    const suffix = escapeHTML(text.slice(idx + q.length, end)) + (end < text.length ? "…" : "");
+    return `${prefix}<mark>${match}</mark>${suffix}`;
+}
+
 function renderConversationList() {
     conversationListEl.innerHTML = "";
     let ids = currentFolderId && folders[currentFolderId]
         ? folders[currentFolderId].conversations.filter(id => conversations[id])
         : Object.keys(conversations);
 
-    if (searchQuery) {
-        const q = searchQuery.toLowerCase();
-        ids = ids.filter(id => (conversations[id].title || "").toLowerCase().includes(q));
+    const q = searchQuery.toLowerCase();
+    const snippets = {}; // id -> snippet HTML (only for content-only matches)
+    if (q) {
+        ids = ids.filter(id => {
+            const convo = conversations[id];
+            const titleMatch = (convo.title || "").toLowerCase().includes(q);
+            const match = (convo.messages || []).find(m => messageText(m.content).toLowerCase().includes(q));
+            if (match) {
+                if (!titleMatch) snippets[id] = buildSnippet(messageText(match.content), searchQuery);
+                return true;
+            }
+            return titleMatch;
+        });
     }
 
     ids.sort((a, b) => convSortKey(conversations[b]) - convSortKey(conversations[a]));
@@ -1190,10 +1284,19 @@ function renderConversationList() {
         li.classList.add("conversation-item");
         if (id === currentConversationId) li.classList.add("active");
 
+        const label = document.createElement("div");
+        label.className = "conversation-label";
         const span = document.createElement("span");
         span.textContent = convo.title;
         span.title = convo.title;
-        li.appendChild(span);
+        label.appendChild(span);
+        if (snippets[id]) {
+            const snippet = document.createElement("div");
+            snippet.className = "conversation-snippet";
+            snippet.innerHTML = snippets[id];
+            label.appendChild(snippet);
+        }
+        li.appendChild(label);
 
         const actions = document.createElement("div");
         actions.className = "conversation-actions";
@@ -1205,7 +1308,7 @@ function renderConversationList() {
 
         span.addEventListener("click", () => switchConversation(id));
         li.addEventListener("click", (e) => {
-            if (e.target === li) switchConversation(id);
+            if (e.target === li || label.contains(e.target)) switchConversation(id);
         });
         actions.querySelector(".folder-assign-btn").addEventListener("click", (e) => {
             e.stopPropagation();
@@ -1307,11 +1410,15 @@ function renderFolderList() {
         const actions = document.createElement("div");
         actions.className = "folder-actions";
         actions.innerHTML = `
+            <button class="model-folder-btn" title="Folder default model">🧠</button>
             <button class="prompt-folder-btn" title="Folder system prompt">📝</button>
             <button class="rename-folder-btn" title="Rename Folder">✏️</button>
             <button class="delete-folder-btn" title="Delete Folder">🗑️</button>`;
         if (typeof folder.systemPrompt === "string" && folder.systemPrompt) {
             actions.querySelector(".prompt-folder-btn").classList.add("has-prompt");
+        }
+        if (validModelPref(folder.modelPref)) {
+            actions.querySelector(".model-folder-btn").classList.add("has-prompt");
         }
         li.appendChild(actions);
 
@@ -1320,6 +1427,33 @@ function renderFolderList() {
             saveFolders();
             renderFolderList();
             renderConversationList();
+        });
+        actions.querySelector(".model-folder-btn").addEventListener("click", (e) => {
+            e.stopPropagation();
+            const items = [{
+                label: "No default",
+                selected: !folder.modelPref,
+                onClick: () => {
+                    delete folder.modelPref;
+                    saveFolders();
+                    renderFolderList();
+                },
+            }];
+            for (const conn of connections) {
+                for (const model of conn.models) {
+                    items.push({
+                        label: `${conn.name} · ${model}`,
+                        selected: !!(folder.modelPref && folder.modelPref.connectionId === conn.id && folder.modelPref.model === model),
+                        onClick: () => {
+                            folder.modelPref = { connectionId: conn.id, model };
+                            saveFolders();
+                            renderFolderList();
+                            toast(`Default model set for folder "${folder.name}".`, "success");
+                        },
+                    });
+                }
+            }
+            showMenu(e.target, items);
         });
         actions.querySelector(".prompt-folder-btn").addEventListener("click", async (e) => {
             e.stopPropagation();
@@ -1432,6 +1566,11 @@ function onModelPickerChange() {
     settings.activeConnectionId = connId;
     settings.activeModel = rest.join("||");
     saveSettings();
+    const conv = conversations[currentConversationId];
+    if (conv) {
+        conv.modelPref = { connectionId: settings.activeConnectionId, model: settings.activeModel };
+        Store.put(conv).catch(e => console.error("Save failed:", e));
+    }
 }
 
 /* ==========================================================================
@@ -2086,8 +2225,13 @@ function attachEventListeners() {
     $("#new-chat-btn").addEventListener("click", createNewConversation);
     $("#create-folder-btn").addEventListener("click", createNewFolder);
     $("#conversation-search").addEventListener("input", (e) => {
-        searchQuery = e.target.value.trim();
-        renderConversationList();
+        const value = e.target.value.trim();
+        if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+        searchDebounceTimer = setTimeout(() => {
+            searchDebounceTimer = null;
+            searchQuery = value;
+            renderConversationList();
+        }, 150);
     });
     $("#export-chat-btn").addEventListener("click", (e) => {
         const conv = currentConv();
@@ -2241,6 +2385,7 @@ async function init() {
     }
     renderFolderList();
     renderModelPicker();
+    applyModelPref(conversations[currentConversationId]);
     populatePresetSelect();
     attachEventListeners();
     autoResizeInput();

--- a/script.js
+++ b/script.js
@@ -850,8 +850,7 @@ function scheduleStreamRender(el, msg) {
 
 function buildApiMessages(conv, uptoIndex = null) {
     const out = [];
-    const sys = conv.systemPrompt !== undefined && conv.systemPrompt !== null
-        ? conv.systemPrompt : settings.systemPrompt;
+    const sys = effectiveSystemPrompt(conv);
     if (sys && sys.trim()) out.push({ role: "system", content: sys });
     const msgs = uptoIndex === null ? conv.messages : conv.messages.slice(0, uptoIndex);
     for (const m of msgs) {
@@ -1237,6 +1236,23 @@ function saveFolders() {
     localStorage.setItem("currentFolderId", currentFolderId === null ? "" : currentFolderId);
 }
 
+/* Returns the folder object containing a conversation id, or null if unfiled. */
+function folderOf(conversationId) {
+    for (const folder of Object.values(folders)) {
+        if (folder.conversations.includes(conversationId)) return folder;
+    }
+    return null;
+}
+
+/* Resolves the system prompt for a conversation: conversation override (even ""),
+ * else the folder default (if non-empty), else the global default. */
+function effectiveSystemPrompt(conv) {
+    if (conv.systemPrompt !== undefined && conv.systemPrompt !== null) return conv.systemPrompt;
+    const folder = folderOf(conv.id);
+    if (folder && typeof folder.systemPrompt === "string" && folder.systemPrompt) return folder.systemPrompt;
+    return settings.systemPrompt;
+}
+
 function loadFolders() {
     try {
         const saved = JSON.parse(localStorage.getItem("folders") || "null");
@@ -1291,8 +1307,12 @@ function renderFolderList() {
         const actions = document.createElement("div");
         actions.className = "folder-actions";
         actions.innerHTML = `
+            <button class="prompt-folder-btn" title="Folder system prompt">📝</button>
             <button class="rename-folder-btn" title="Rename Folder">✏️</button>
             <button class="delete-folder-btn" title="Delete Folder">🗑️</button>`;
+        if (typeof folder.systemPrompt === "string" && folder.systemPrompt) {
+            actions.querySelector(".prompt-folder-btn").classList.add("has-prompt");
+        }
         li.appendChild(actions);
 
         span.addEventListener("click", () => {
@@ -1300,6 +1320,21 @@ function renderFolderList() {
             saveFolders();
             renderFolderList();
             renderConversationList();
+        });
+        actions.querySelector(".prompt-folder-btn").addEventListener("click", async (e) => {
+            e.stopPropagation();
+            const value = await textDialog({
+                title: `System Prompt — folder "${folder.name}"`,
+                message: "Default system prompt for every chat in this folder. Chats can still override it individually. Leave empty to fall back to the global default.",
+                value: folder.systemPrompt || "",
+                multiline: true,
+                placeholder: "You are a helpful assistant.",
+            });
+            if (value === null) return;
+            folder.systemPrompt = value;
+            saveFolders();
+            renderFolderList();
+            toast(`System prompt updated for folder "${folder.name}".`, "success");
         });
         actions.querySelector(".rename-folder-btn").addEventListener("click", async (e) => {
             e.stopPropagation();
@@ -2010,10 +2045,10 @@ function attachEventListeners() {
         const conv = currentConv();
         if (!conv) return;
         const effective = conv.systemPrompt !== undefined && conv.systemPrompt !== null
-            ? conv.systemPrompt : (settings.systemPrompt || "");
+            ? conv.systemPrompt : effectiveSystemPrompt(conv);
         const value = await textDialog({
             title: "System Prompt (this chat)",
-            message: "Sent as the system message with every request in this conversation. Leave empty for none.",
+            message: "Sent as the system message with every request in this conversation. Overrides the folder and global defaults. Leave empty for none.",
             value: effective,
             multiline: true,
             placeholder: "You are a helpful assistant.",

--- a/style.css
+++ b/style.css
@@ -375,6 +375,11 @@ body.dark-mode #model-picker {
     padding: 2px;
 }
 
+.folder-actions button.has-prompt {
+    opacity: 1;
+    filter: drop-shadow(0 0 2px var(--color-primary));
+}
+
 /* Popup menus (folder assignment, export) */
 .popup-menu {
     position: fixed;

--- a/style.css
+++ b/style.css
@@ -287,6 +287,25 @@ body.dark-mode #model-picker {
     white-space: nowrap;
 }
 
+.conversation-label {
+    flex: 1;
+    min-width: 0;
+}
+
+.conversation-snippet {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.conversation-snippet mark {
+    background: rgba(74, 144, 226, 0.35);
+    color: inherit;
+    border-radius: 2px;
+}
+
 .conversation-item:hover {
     background-color: rgba(74, 144, 226, 0.1);
 }
@@ -1167,6 +1186,21 @@ body.dark-mode .message-text :not(pre) > code {
 
 .toast.error { background-color: var(--color-danger); }
 .toast.success { background-color: #2e9e44; }
+
+.toast .toast-action {
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    color: #fff;
+    border-radius: 4px;
+    padding: 0.1rem 0.5rem;
+    margin-left: 0.75rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+
+.toast .toast-action:hover {
+    background: rgba(255, 255, 255, 0.15);
+}
 
 @keyframes toast-in {
     from { transform: translateX(30px); opacity: 0; }


### PR DESCRIPTION
## Summary

Two commits that build on the recent UI overhaul, focused on organization and day-to-day usability.

### Folders as projects
- **Folder system prompts** (📝 on the folder row): every chat in a folder inherits its prompt. Resolution per request: chat override → folder default → global default. The per-chat 📝 dialog pre-fills the inherited value so you can see what's active.
- **Folder default models** (🧠 on the folder row): pick from a menu of all configured connection/model combos; new and existing chats in the folder default to it.
- **Per-chat model memory**: the header picker remembers which model each conversation last used and restores it when switching chats. Prefs pointing at deleted connections/models fall through silently.

### Search
- Sidebar search now matches **message content** as well as titles (case-insensitive), showing a highlighted snippet around the first match for content-only hits. Input debounced 150 ms.

### Undo instead of confirm
- Deleting a message or conversation is now immediate with a 6-second **Undo** toast (restores folder membership too), replacing the irreversible message delete and the conversation confirm dialog. Folder deletion keeps its confirm since it's rarer.

## Notes for review
- Snippet HTML is assembled from individually-escaped pieces before the `<mark>` wrap, so message content can't inject markup.
- `toast()` gained an optional `action` parameter; existing call sites are unchanged.
- Conversation-undo snapshots are taken before folder membership is stripped, so Undo restores the folder assignment.

## Test plan
- `node --check script.js` passes; diff reviewed line-by-line
- Manual: set folder prompt + model → new chat in folder inherits both; switch between chats with different models → picker follows; search a word that only exists in message bodies → snippet appears; delete message/conversation → Undo restores fully
